### PR TITLE
add unique connectionId per connection

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,6 +90,7 @@ class WebSocketJSONServer extends EventEmitter {
 
     this.wss.on('connection', (ws,data) => {
       console.info({ action: sAction + '.on.connection', serverId: this.serverId, connectedClients: this.connectedClients() })
+      ws.connectionId = uuid()
       ws.isAlive = true;
       ws.on('pong', () => { 
         ws.isAlive = true;


### PR DESCRIPTION
Currently there isn't a way for the socket server to differentiate connections made by the same user.

adding connectionId property per connection